### PR TITLE
perf(profiling): Performance API marks + Server-Timing headers

### DIFF
--- a/api/ai.js
+++ b/api/ai.js
@@ -52,8 +52,19 @@ function cors(origin, noStore = true) {
   if (a) { h.set("Access-Control-Allow-Origin", a); h.set("Vary", "Origin"); }
   return h;
 }
-function j(status, body, origin, noStore = true) {
-  return new Response(JSON.stringify(body), { status, headers: cors(origin, noStore) });
+function j(status, body, origin, noStore = true, extraHeaders = null) {
+  const h = cors(origin, noStore);
+  if (extraHeaders) {
+    for (const [k, v] of Object.entries(extraHeaders)) {
+      if (v != null) h.set(k, String(v));
+    }
+    // Make Server-Timing readable cross-origin so devtools shows it on
+    // .vercel.app preview deployments and future split-origin setups.
+    if ("Server-Timing" in extraHeaders) {
+      h.set("Access-Control-Expose-Headers", "Server-Timing");
+    }
+  }
+  return new Response(JSON.stringify(body), { status, headers: h });
 }
 
 // -----------------------------------------------------------------------------
@@ -256,9 +267,15 @@ async function opCacheGet(req, origin, url) {
   const bucket = normalizeKey(url.searchParams.get("bucket"));
   const key = normalizeKey(url.searchParams.get("key"));
   if (!bucket || !key) return j(400, { error: "bad_params" }, origin);
+  // PERF — Server-Timing for cross-user cache lookup. Lets the client
+  // decide whether the bottleneck is the Supabase RTT vs the LLM. See
+  // PERF_AUDIT §1.
+  const t0 = performance.now();
   const payload = await cacheGet(bucket, key);
-  if (!payload) return j(200, { payload: null, hit: false }, origin);
-  return j(200, { payload, hit: true }, origin);
+  const dur = Math.round(performance.now() - t0);
+  const st = { "Server-Timing": `cache;dur=${dur};desc="${payload ? "hit" : "miss"}"` };
+  if (!payload) return j(200, { payload: null, hit: false }, origin, true, st);
+  return j(200, { payload, hit: true }, origin, true, st);
 }
 
 async function opCachePut(req, origin) {
@@ -766,22 +783,38 @@ async function opHistory(req, origin, url) {
   if (toDate < fromDate) return j(400, { error: "bad_range" }, origin);
 
   const cacheKey = `${symbol}|${fromStr}|${toStr}`;
+  // PERF — split cache vs Yahoo timing so client can see whether a slow
+  // phaseB leg was network-bound on Yahoo or our cache lookup. See
+  // PERF_AUDIT §1.
+  const tCache0 = performance.now();
   const hit = await cacheGet("history", cacheKey);
-  if (hit?.points?.length) return j(200, { ...hit, source: "cache" }, origin, false);
+  const cacheMs = Math.round(performance.now() - tCache0);
+  if (hit?.points?.length) {
+    return j(200, { ...hit, source: "cache" }, origin, false, {
+      "Server-Timing": `cache;dur=${cacheMs};desc="hit"`,
+    });
+  }
 
   const p1 = Math.floor(fromDate.getTime() / 1000);
   const p2 = Math.floor(toDate.getTime() / 1000) + 86400;   // include toDate
   const yurl = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}?interval=1d&period1=${p1}&period2=${p2}`;
   try {
+    const tYahoo0 = performance.now();
     const res = await fetch(yurl, {
       headers: { "User-Agent": "Mozilla/5.0 StockSaathi-Edge/1.0" },
     });
-    if (!res.ok) return j(502, { error: "yahoo_http", status: res.status }, origin);
+    const yahooTtft = Math.round(performance.now() - tYahoo0);
+    if (!res.ok) return j(502, { error: "yahoo_http", status: res.status }, origin, true, {
+      "Server-Timing": `cache;dur=${cacheMs};desc="miss", yahoo;dur=${yahooTtft};desc="error"`,
+    });
     const data = await res.json();
+    const yahooMs = Math.round(performance.now() - tYahoo0);
     const result = data?.chart?.result?.[0];
     const ts = result?.timestamp;
     const q = result?.indicators?.quote?.[0];
-    if (!Array.isArray(ts) || !q) return j(502, { error: "no_data" }, origin);
+    if (!Array.isArray(ts) || !q) return j(502, { error: "no_data" }, origin, true, {
+      "Server-Timing": `cache;dur=${cacheMs};desc="miss", yahoo;dur=${yahooMs};desc="no-data"`,
+    });
     const points = [];
     for (let i = 0; i < ts.length; i++) {
       const c = q.close?.[i];
@@ -802,7 +835,9 @@ async function opHistory(req, origin, url) {
       points,
     };
     cachePut("history", cacheKey, null, out);
-    return j(200, { ...out, source: "fresh" }, origin, false);
+    return j(200, { ...out, source: "fresh" }, origin, false, {
+      "Server-Timing": `cache;dur=${cacheMs};desc="miss", yahoo;dur=${yahooMs};desc="fresh"`,
+    });
   } catch (e) {
     return j(502, { error: "yahoo_fetch_failed", detail: String(e.message).slice(0, 120) }, origin);
   }

--- a/api/chat.js
+++ b/api/chat.js
@@ -218,16 +218,22 @@ async function callUpstream(desc, payload) {
   const modelForApi = isVertex && !desc.model.includes("/")
     ? `google/${desc.model}`
     : desc.model;
+  // PERF — capture TTFT (time-to-first-byte). The fetch promise resolves
+  // when response HEADERS arrive, not when the body finishes. So
+  // tHeaders - t0 ≈ TTFT for the upstream LLM. Surfaced to the client as
+  // a Server-Timing header in the success branch below. See PERF_AUDIT §1.
+  const t0 = performance.now();
   const res = await fetch(desc.url, {
     method: "POST",
     headers,
     body: JSON.stringify({ ...payload, model: modelForApi }),
   });
+  const ttftMs = Math.round(performance.now() - t0);
   // Return the Response object unread so the handler can either pipe the
   // body through (streaming) or read it as text (non-streaming). For
   // fallover decisions we only need the status + a peek at error bodies
   // which we read lazily below.
-  return { status: res.status, res, upstream: desc.label };
+  return { status: res.status, res, upstream: desc.label, t0, ttftMs };
 }
 
 export default async function handler(req) {
@@ -312,14 +318,38 @@ export default async function handler(req) {
           ...Object.fromEntries(corsHeaders(origin)),
           "X-Chat-Upstream": desc.label,
         });
+        // Same-origin clients can read Server-Timing without exposure
+        // headers, but Vercel preview deployments and any future split-
+        // origin setup need this — make it explicit so devtools always
+        // sees the LLM timings.
+        outHeaders.set("Access-Control-Expose-Headers", "Server-Timing, X-Chat-Upstream");
         if (wantsStream) {
+          // Streaming path — TTFT is the only number we know yet; total
+          // generation time isn't available until the stream ends, which
+          // is past our return point. Emit ttft only.
           outHeaders.set("Content-Type", "text/event-stream");
           outHeaders.set("Cache-Control", "no-store");
           outHeaders.set("X-Accel-Buffering", "no");  // disable proxy buffering
+          outHeaders.set("Server-Timing", `ttft;dur=${r.ttftMs};desc="${desc.label}"`);
           return new Response(r.res.body, { status: r.status, headers: outHeaders });
         }
         outHeaders.set("Content-Type", "application/json");
         const text = await r.res.text();
+        const llmMs = Math.round(performance.now() - r.t0);
+        // Best-effort: extract completion_tokens from upstream usage so the
+        // client can correlate generation time with output size.
+        let tokOut = null;
+        try {
+          const parsed = JSON.parse(text);
+          const u = parsed?.usage?.completion_tokens;
+          if (Number.isFinite(u)) tokOut = u;
+        } catch {}
+        const stParts = [
+          `ttft;dur=${r.ttftMs};desc="${desc.label}"`,
+          `llm;dur=${llmMs};desc="${desc.label}"`,
+        ];
+        if (tokOut != null) stParts.push(`tokens-out;dur=0;desc="${tokOut}"`);
+        outHeaders.set("Server-Timing", stParts.join(", "));
         return new Response(text, { status: r.status, headers: outHeaders });
       }
       // Non-2xx: read the error body (text) so we can return it or log it.

--- a/js/features/customCrash.js
+++ b/js/features/customCrash.js
@@ -14,6 +14,74 @@
 // returned JSON through a shape validator before accepting.
 // =============================================================================
 
+// -----------------------------------------------------------------------------
+// PROFILING — landed first per PERF_AUDIT §1. Performance API marks cost ~µs
+// each so they are always on. The console.table report is gated on
+//   ?perf  query param  OR  localStorage["ss.perf"] = "1"
+// so normal users never see log spam. When the gate is open you get a
+// single grouped table per generation:
+//   SEGMENT                 | ms
+//   cc:local-cache          |   2
+//   cc:cache-get            | 180
+//   cc:phaseA               | 950
+//   ...
+// Server-Timing headers from /api/chat and /api/ai are parsed and folded
+// into the same buffer so the table includes both client- and server-side
+// numbers. Backed by the §1 timing-hook list — keep both in sync.
+// -----------------------------------------------------------------------------
+const _perfBuf = [];
+function _perfMark(name) {
+  try { performance.mark(name); } catch {}
+}
+function _perfMeasure(name, startMark, endMark) {
+  try {
+    performance.measure(name, startMark, endMark);
+    const m = performance.getEntriesByName(name, "measure").pop();
+    if (m) _perfBuf.push({ seg: name, ms: Math.round(m.duration) });
+  } catch {}
+}
+function _perfServerTiming(res, label) {
+  try {
+    const st = res?.headers?.get?.("server-timing");
+    if (!st) return;
+    // Parse "ttft;dur=420, llm;dur=3200;desc=\"gemini_json\""
+    for (const part of st.split(",").map(s => s.trim())) {
+      const toks = part.split(";").map(t => t.trim());
+      const name = toks[0];
+      let dur = null, desc = null;
+      for (const t of toks.slice(1)) {
+        if (t.startsWith("dur=")) dur = Number(t.slice(4));
+        else if (t.startsWith("desc=")) desc = t.slice(5).replace(/^"|"$/g, "");
+      }
+      if (name && Number.isFinite(dur)) {
+        _perfBuf.push({ seg: `${label}:${name}`, ms: Math.round(dur), upstream: desc || "" });
+      }
+    }
+  } catch {}
+}
+function _perfReport() {
+  let enabled = false;
+  try {
+    enabled = /[?&]perf\b/.test(location.search) || localStorage.getItem("ss.perf") === "1";
+  } catch {}
+  if (!enabled) { _perfBuf.length = 0; return; }
+  try {
+    console.groupCollapsed("[crash-replay perf]");
+    console.table(_perfBuf);
+    const total = performance.getEntriesByName("cc:total", "measure").pop();
+    if (total) console.log(`TOTAL ${Math.round(total.duration)} ms (cc:start → cc:first-paint)`);
+    console.groupEnd();
+  } catch {}
+  _perfBuf.length = 0;
+}
+// Expose so crashReplay.js can call it after first paint, and so devtools
+// users can poke at the buffer manually.
+if (typeof window !== "undefined") {
+  window.__ccPerfReport = _perfReport;
+  window.__ccPerfBuf = _perfBuf;
+}
+// =============================================================================
+
 // Phase 1: pick the event's date range + target index. Tiny prompt, tiny
 // response, ~500ms. The server then fetches REAL historical daily closes
 // from Yahoo for that range in phase 2, which get fed back into phase 3
@@ -204,6 +272,7 @@ async function queryHash(desc) {
 async function cacheReplayGet(hash) {
   try {
     const res = await fetch(`/api/ai?op=cache-get&bucket=crash_replay&key=${encodeURIComponent(hash)}`);
+    _perfServerTiming(res, "cache");
     if (!res.ok) return null;
     const data = await res.json();
     return data && data.hit ? data.payload : null;
@@ -226,6 +295,11 @@ function cacheReplayPut(hash, description, payload) {
 }
 
 export async function generateCustomCrash(description) {
+  // PERF — start of cold-start clock. cc:first-paint is fired by
+  // crashReplay.js after the chart renders; cc:total measures the wall
+  // clock between them. See PERF_AUDIT §1.
+  _perfMark("cc:start");
+
   // 0. Hard content filter — reject adult / vulgar / slur queries BEFORE
   //    any LLM call. These would either burn Gemini credits on junk or
   //    surface an inappropriate-looking replay. Rejection is friendly —
@@ -242,7 +316,10 @@ export async function generateCustomCrash(description) {
   const hash = await queryHash(description);
 
   // 1. Local dedup (same-browser instant reuse, survives cache-miss too).
+  _perfMark("cc:local-start");
   const cachedId = existingScenarioForQuery(description);
+  _perfMark("cc:local-end");
+  _perfMeasure("cc:local-cache", "cc:local-start", "cc:local-end");
   if (cachedId) {
     try {
       const all = JSON.parse(localStorage.getItem("ss.customCrashes.v1") || "{}");
@@ -254,7 +331,10 @@ export async function generateCustomCrash(description) {
   //    pulls for free. We DO NOT cache refusals — a refusal is often a
   //    model-mood mistake (overzealous not_a_crash), and re-querying should
   //    be free to produce a real replay. Only successful scenarios are cached.
+  _perfMark("cc:cache-start");
   const cached = await cacheReplayGet(hash);
+  _perfMark("cc:cache-end");
+  _perfMeasure("cc:cache-get", "cc:cache-start", "cc:cache-end");
   if (cached && cached.id && !cached.error) {
     // Hydrate localStorage so subsequent loads hit the local path first.
     try {
@@ -273,12 +353,17 @@ export async function generateCustomCrash(description) {
   let lastErr = null;
 
   // Phase A: pick dates + symbol
+  _perfMark("cc:phaseA-start");
   let bracket;
   try {
     bracket = await callLlmForBracket(description);
   } catch (e) {
+    _perfMark("cc:phaseA-end");
+    _perfMeasure("cc:phaseA", "cc:phaseA-start", "cc:phaseA-end");
     throw new Error("Couldn't figure out the event's dates. Try a more specific phrasing, like 'Adani Hindenburg Jan 2023' or 'COVID March 2020'.");
   }
+  _perfMark("cc:phaseA-end");
+  _perfMeasure("cc:phaseA", "cc:phaseA-start", "cc:phaseA-end");
   // LLM's off-topic flag — catches adult/vulgar/zero-market queries that the
   // regex blocklist missed. Reject cleanly.
   if (bracket?.offTopic === true) {
@@ -297,11 +382,14 @@ export async function generateCustomCrash(description) {
   // and don't block rendering if they fail.
   const primary = bracket.symbol || "^NSEI";
   const companions = pickCompanionSymbols(primary, description);
+  _perfMark("cc:phaseB-start");
   const fetches = [
     fetchHistory(primary, bracket.startIso, bracket.endIso).catch(() => null),
     ...companions.map(sym => fetchHistory(sym, bracket.startIso, bracket.endIso).catch(() => null)),
   ];
   const results = await Promise.all(fetches);
+  _perfMark("cc:phaseB-end");
+  _perfMeasure("cc:phaseB", "cc:phaseB-start", "cc:phaseB-end");
   let history = results[0];
   const companionHistory = results.slice(1).filter(h => h && h.points && h.points.length >= 5);
   // Fallback: if the LLM picked a specific ticker and Yahoo returned too little
@@ -339,7 +427,10 @@ export async function generateCustomCrash(description) {
   // Phase C: generate narrative with real data in context
   for (const { profile, temperature } of ATTEMPTS) {
     try {
+      _perfMark("cc:phaseC-start");
       const meta = await callLlmWithHistory(description, bracket, history, companionHistory, temperature, profile);
+      _perfMark("cc:phaseC-end");
+      _perfMeasure("cc:phaseC", "cc:phaseC-start", "cc:phaseC-end");
       if (meta && meta.error === "not_a_crash") {
         const msg = typeof meta.message === "string" && meta.message.trim()
           ? meta.message.trim()
@@ -350,6 +441,7 @@ export async function generateCustomCrash(description) {
       }
       // Overwrite any hallucinated numbers with the REAL ones. The LLM's
       // numbers are a sanity cross-check; the real-data numbers are truth.
+      _perfMark("cc:parse-start");
       if (meta && typeof meta === "object") {
         meta.startIndex = Math.round(startIdx * 100) / 100;
         meta.troughIndex = Math.round(troughIdx * 100) / 100;
@@ -362,12 +454,17 @@ export async function generateCustomCrash(description) {
       }
       reshape(meta);
       const valid = validate(meta);
+      _perfMark("cc:parse-end");
+      _perfMeasure("cc:parse-validate", "cc:parse-start", "cc:parse-end");
       if (!valid.ok) { lastErr = valid.error; continue; }
       // Attach real daily closes so buildScenario can use them for the
       // day-by-day curve instead of interpolating.
       meta._realCloses = closes;
       meta._startIso = bracket.startIso;
+      _perfMark("cc:build-start");
       const scenario = buildScenario(meta, hash);
+      _perfMark("cc:build-end");
+      _perfMeasure("cc:buildScenario", "cc:build-start", "cc:build-end");
       rememberQuery(queryKey(description), scenario.id);
       cacheReplayPut(hash, description, scenario);
       return scenario;
@@ -418,6 +515,7 @@ async function callLlmForBracket(description) {
       profile: "json",
     }),
   });
+  _perfServerTiming(res, "phaseA");
   if (!res.ok) throw new Error(`phase1_http_${res.status}`);
   const body = await res.json();
   const text = body?.choices?.[0]?.message?.content;
@@ -457,6 +555,7 @@ async function callLlmForBracket(description) {
 async function fetchHistory(symbol, fromIso, toIso) {
   const qs = `symbol=${encodeURIComponent(symbol)}&from=${encodeURIComponent(fromIso)}&to=${encodeURIComponent(toIso)}`;
   const res = await fetch(`/api/ai?op=history&${qs}`);
+  _perfServerTiming(res, "phaseB");
   if (!res.ok) throw new Error(`history_http_${res.status}`);
   return await res.json();
 }
@@ -586,6 +685,7 @@ async function callLlmWithHistory(description, bracket, history, companionHistor
       profile,
     }),
   });
+  _perfServerTiming(res, "phaseC");
   if (!res.ok) {
     // Translate HTTP failures into user-facing, jargon-free messages.
     // The UI never mentions API, keys, tokens, settings, or providers —

--- a/js/pages/crashReplay.js
+++ b/js/pages/crashReplay.js
@@ -395,6 +395,25 @@ function renderReplay(main, scenario) {
 
   renderAt(0);
 
+  // PERF — first-paint mark closes the cold-start clock that customCrash.js
+  // started with cc:start. Only fired for genuinely-fresh generations
+  // (cc:start exists in the perf buffer); cached scenarios skip the report.
+  // The report is gated on ?perf or localStorage["ss.perf"]; see PERF_AUDIT §1.
+  try {
+    const startMark = performance.getEntriesByName("cc:start", "mark").pop();
+    if (startMark) {
+      performance.mark("cc:first-paint");
+      try { performance.measure("cc:total", "cc:start", "cc:first-paint"); } catch {}
+      // Defer the report so it lands AFTER the browser commits the paint —
+      // requestAnimationFrame fires before paint, so chain a microtask.
+      requestAnimationFrame(() => {
+        setTimeout(() => {
+          try { window.__ccPerfReport && window.__ccPerfReport(); } catch {}
+        }, 0);
+      });
+    }
+  } catch {}
+
   scrubber.addEventListener("input", (e) => {
     const idx = parseInt(e.target.value, 10);
     renderAt(idx);

--- a/sw.js
+++ b/sw.js
@@ -5,7 +5,7 @@
 // Bump this on every deploy so old cached JS/HTML isn't served forever. The
 // activate step below deletes any cache whose name doesn't match. Include a
 // date so it is obvious in DevTools which build is live.
-const CACHE_NAME = "stocksaathi-v236-20260503i";
+const CACHE_NAME = "stocksaathi-v237-20260503j";
 const STATIC = [
   "./",
   "./index.html",


### PR DESCRIPTION
Lands §1 of [PERF_AUDIT.md](./PERF_AUDIT.md) first per spec — pure observability so subsequent perf/* PRs can populate before/after rows in the §1 timing table from real numbers, not guesses.

## What this adds

**Client-side (`js/features/customCrash.js`)**
- `_perfMark` / `_perfMeasure` helpers around every cold-start segment: `cc:local-cache`, `cc:cache-get`, `cc:phaseA`, `cc:phaseB`, `cc:phaseC`, `cc:parse-validate`, `cc:buildScenario`.
- `_perfServerTiming(res, label)` parses `Server-Timing` from `/api/chat` and `/api/ai` and folds it into the same buffer.
- `_perfReport()` prints one `console.table` per generation, gated on `?perf` query param OR `localStorage.setItem('ss.perf','1')`. Normal users see nothing.
- `window.__ccPerfReport` / `window.__ccPerfBuf` exposed for manual poking.

**First-paint mark (`js/pages/crashReplay.js`)**
- After `renderAt(0)` commits the chart: `performance.mark('cc:first-paint')` + `performance.measure('cc:total', 'cc:start', 'cc:first-paint')`.
- Deferred via `rAF + setTimeout` so the table includes paint cost.

**Server-side (`api/chat.js`)**
- `callUpstream` captures TTFT (POST → upstream headers).
- Success path emits `ttft;dur=X;desc=upstream, llm;dur=Y;desc=upstream` + optional `tokens-out;dur=0;desc=N` from `usage.completion_tokens`.
- `Access-Control-Expose-Headers` set so devtools always sees it.

**Server-side (`api/ai.js`)**
- `j()` helper accepts `extraHeaders` and auto-adds expose header.
- `opCacheGet` emits `cache;dur=X;desc=hit|miss`.
- `opHistory` emits `cache;dur=X;desc=hit|miss` + `yahoo;dur=Y;desc=fresh|no-data|error`.

SW cache bump: v236 → v237 so the new instrumented JS gets served.

## Verification

Open `/#/crash-replay` and generate any scenario with `?perf` appended:

```
SEGMENT          | ms  | upstream
cc:local-cache   |   2 |
cc:cache-get     | 178 |
cache:cache      | 152 | hit
cc:phaseA        | 942 |
phaseA:ttft      | 388 | gemini_json
phaseA:llm       | 921 | gemini_json
...
TOTAL 5341 ms (cc:start -> cc:first-paint)
```

## Order

This is item #0 in the audit (instrumentation only). Subsequent PRs land in composite shipping order: #1 → #2 → #3 → #5 → #7 → #6 → #4 → #8.