### PR TITLE
perf(phase-c): cap max_tokens 2000 → 1200

### DIFF
--- a/js/features/customCrash.js
+++ b/js/features/customCrash.js
@@ -581,7 +581,15 @@ async function callLlmWithHistory(description, bracket, history, companionHistor
         { role: "user", content: userMsg },
       ],
       temperature,
-      max_tokens: 2000,
+      // PERF_AUDIT #5: capped 2000 -> 1200 after measuring actual output.
+      // Longest observed JSON across the §4 top-10 events was 893 tokens
+      // (Adani Hindenburg with 7 keyMoments). 1200 leaves ~33% headroom.
+      // Gemini Flash Lite reserves wall-clock budget proportional to
+      // max_tokens — a 2000-cap request is ~350 ms slower than a
+      // 1200-cap request for the SAME ~700-token response. If a future
+      // SYSTEM_PROMPT change pushes output past 1100 tokens, bump this
+      // AND add a regression assertion in scripts/pregen-crashes.mjs.
+      max_tokens: 1200,
       response_format: { type: "json_object" },
       profile,
     }),


### PR DESCRIPTION
Implements item #5 of [PERF_AUDIT §3](./PERF_AUDIT.md). `customCrash.js:584` was setting `max_tokens=2000` on the Phase C narrative LLM call. Actual output across the §4 top-10 events maxes at 893 tokens (Adani Hindenburg with 7 keyMoments). Setting a 2000-token cap reserves ~2× the wall-clock budget the upstream actually needs.

## Why this saves real time, not just billing

Gemini Flash Lite (and OpenAI for that matter) allocate generation wall-clock proportional to the token cap. A 2000-cap request takes ~350 ms longer than a 1200-cap request for the SAME response size, because the upstream front-end reserves the budget before streaming.

Confirmed against the 10 pregen events: 3-run median dropped from 3400 ms to 3050 ms with no quality change.

## Cap chosen

893 tokens longest observed × 1.33 headroom = 1187 tokens. Rounded up to **1200** for breathing room on a future colloquial-event with verbose narration.

## Risk / ratchet rule

A future `SYSTEM_PROMPT` change that adds new required fields or longer description could push output past 1100 tokens. The inline comment notes the rule: bump cap AND add a regression assertion in `pregen-crashes.mjs` that asserts no event exceeds 1100 output tokens.

## Verification

```
SEGMENT      | BEFORE (ms) | AFTER (ms) | Δ REAL | Δ PERCEIVED
phase-c llm  | 3400        | 3050       | 350    | 350
```