### PR TITLE
perf(featured): Featured Replays click-through using pre-gen phrasings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ Thumbs.db
 dist/
 build/
 *.log
+.vercel

--- a/PERF_AUDIT.md
+++ b/PERF_AUDIT.md
@@ -111,6 +111,21 @@ ms (cache hit only).
 For each top item: file:line, diff applied, gotchas, before/after row
 from §1's table.
 
+### PR map (status: all open against `main`, 2026-05-03)
+
+| Item | Branch | PR | Real | Perceived |
+|---|---|---|---|---|
+| §1  | `perf/01-profiling-hooks`     | [#2](https://github.com/Ali-Arbab/StockSaathi/pull/2) | 0   | 0   |
+| #1  | `perf/03-pregen-top10`        | [#3](https://github.com/Ali-Arbab/StockSaathi/pull/3) | 5500 (top-10) | 5500 |
+| #2  | `perf/02-deterministic-router`| [#4](https://github.com/Ali-Arbab/StockSaathi/pull/4) | 950 | 950 |
+| #3  | `perf/04-race-cache-vs-llm`   | [#5](https://github.com/Ali-Arbab/StockSaathi/pull/5) | 180 | 180 |
+| #5  | `perf/05-cap-phase-c-tokens`  | [#6](https://github.com/Ali-Arbab/StockSaathi/pull/6) | 350 | 350 |
+| #7  | `perf/07-drop-companions`     | [#7](https://github.com/Ali-Arbab/StockSaathi/pull/7) | 200-400 | 200-400 |
+| #6  | `perf/06-trim-prompts`        | [#8](https://github.com/Ali-Arbab/StockSaathi/pull/8) | 120 | 120 |
+| #4  | `perf/08-stream-phase-c`      | [#9](https://github.com/Ali-Arbab/StockSaathi/pull/9) | 0   | 1500-2000 |
+
+Merge order: §1 → #1 → #2 → #3 → #5 → #7 → #6 (depends on #2) → #4.
+
 ### Item 1 — Pre-generate top 10 (branch `perf/03-pregen-top10`)
 
 **File:** `app/scripts/pregen-crashes.mjs` (new). Calls the same

--- a/js/pages/crashReplay.js
+++ b/js/pages/crashReplay.js
@@ -12,6 +12,25 @@ import { recordCoachMessage, setState, getState } from "../state.js";
 import { navigate } from "../router.js";
 import { generateCustomCrash } from "../features/customCrash.js";
 
+// Featured replays — canonical phrasings that scripts/pregen-crashes.mjs
+// has populated into the cross-user cache. Clicking any of these calls
+// generateCustomCrash with the exact phrasing → cache hit → instant
+// load. MUST stay in sync with EVENTS in scripts/pregen-crashes.mjs.
+// If pregen hasn't run yet, the click still works but pays full
+// generation cost on first user.
+const FEATURED_PHRASINGS = [
+  { phrase: "Harshad Mehta 1992",            blurb: "Bombay's first big stock-broker scam — Sensex doubled then halved.", range: "Apr 1992 → Aug 1992" },
+  { phrase: "Dot Com 2000",                  blurb: "Indian IT pulled into the global tech bust.",                          range: "Mar 2000 → Jun 2000" },
+  { phrase: "Global Financial Crisis 2008",  blurb: "Lehman → Nifty fell 60% over six months.",                             range: "Sep 2008 → Mar 2009" },
+  { phrase: "Satyam scandal 2009",           blurb: "Ramalinga Raju's confession letter, IT sector circuit-breakers.",     range: "Jan 2009 → Apr 2009" },
+  { phrase: "IL&FS collapse 2018",           blurb: "AAA-rated NBFC defaults trigger a credit-market freeze.",              range: "Sep 2018 → Jan 2019" },
+  { phrase: "DHFL crisis 2019",              blurb: "Housing finance giant unravels live.",                                  range: "Jun 2019 → Dec 2019" },
+  { phrase: "YES Bank moratorium 2020",      blurb: "RBI freezes withdrawals, retail equity-holder gets wiped to ₹0.",     range: "Mar 2020 → Jul 2020" },
+  { phrase: "COVID March 2020",              blurb: "Fastest 35% drop in Nifty history. Recovered in 5 months.",            range: "Feb 2020 → Aug 2020" },
+  { phrase: "Paytm IPO Nov 2021",            blurb: "Listed at ₹2150, fell 27% on debut day. Six months in: -75%.",        range: "Nov 2021 → Apr 2022" },
+  { phrase: "Adani Hindenburg Jan 2023",     blurb: "Short-seller report wipes ₹10 lakh crore from group market cap.",     range: "Jan 2023 → Jun 2023" },
+];
+
 // Hotfix45b: post-process narration text to fix common LLM mis-phrasings.
 // Today's known issue: the LLM sometimes writes 'opens at â‚¹X' when the
 // startIndex/troughIndex/endIndex values are CLOSING prices (closes[0]
@@ -93,6 +112,23 @@ function renderSelector(main) {
       `).join("")}
     </div>
 
+    <div style="margin-top: var(--sp-6); margin-bottom: var(--sp-3);">
+      <h3 style="margin: 0;">Featured replays</h3>
+      <p class="muted text-sm">Pre-generated for instant load. Real Yahoo data, AI-built narration.</p>
+    </div>
+    <div class="crash-scenarios" id="featured-replays">
+      ${FEATURED_PHRASINGS.map(p => `
+        <button class="crash-scenario" data-featured="${escapeAttr(p.phrase)}">
+          <div class="flex items-center justify-between">
+            <h4>${escapeHtml(p.phrase)}</h4>
+            <span class="pill pill-brand">⚡ instant</span>
+          </div>
+          <div class="desc">${escapeHtml(p.blurb)}</div>
+          <div class="meta">${escapeHtml(p.range)}</div>
+        </button>
+      `).join("")}
+    </div>
+
     <div class="card" style="margin-top: var(--sp-8); text-align: center;">
       <h3 style="margin-bottom: var(--sp-2);">Tip</h3>
       <p class="muted">
@@ -102,7 +138,7 @@ function renderSelector(main) {
     </div>
   `;
 
-  main.querySelectorAll(".crash-scenario").forEach(btn => {
+  main.querySelectorAll(".crash-scenario[data-id]").forEach(btn => {
     btn.addEventListener("click", () => {
       location.hash = "#/crash-replay/" + btn.dataset.id;
     });
@@ -111,6 +147,16 @@ function renderSelector(main) {
   const input = main.querySelector("#custom-crash-input");
   const button = main.querySelector("#custom-crash-btn");
   const status = main.querySelector("#custom-crash-status");
+
+  // Featured-replay click → run the same generateCustomCrash flow as
+  // typing the phrase manually. Cache-hit when scripts/pregen-crashes.mjs
+  // has populated the row; falls back to live generation otherwise.
+  main.querySelectorAll(".crash-scenario[data-featured]").forEach(btn => {
+    btn.addEventListener("click", () => {
+      input.value = btn.dataset.featured;
+      trigger();
+    });
+  });
 
   async function trigger() {
     const q = (input.value || "").trim();


### PR DESCRIPTION
Implements the deferred follow-up from [PR #3](https://github.com/Ali-Arbab/StockSaathi/pull/3) (`perf/03-pregen-top10`). Adds a Featured Replays section to `/#/crash-replay` between the curated and custom-input cards. Each card is one of the 10 canonical phrasings that `scripts/pregen-crashes.mjs` has populated.

## Click-through behaviour

- Card click pre-fills the custom-input box with the canonical phrasing AND immediately fires the `trigger()` flow.
- `generateCustomCrash` hashes the phrasing the same way, hits the cross-user cache (populated by pregen), returns the cached scenario in **~250 ms**.
- If pregen hasn't run yet, the click still works — pays full generation cost for the first user, then warms the cache for everyone after.

## Why this is its own PR

- #3 is about the **cache-population mechanism** (script + version-gate).
- This PR is about the **surfacing** — different file, different test surface, independently mergeable. Reviewer can take #3 first, run the pregen script, then merge this once cache is warm.

## Sync constraint

`FEATURED_PHRASINGS` list MUST stay in sync with `EVENTS` in `scripts/pregen-crashes.mjs`. Both files have a 'MUST stay in sync' comment.

## Verification (after #3 lands and pregen runs)

| User action | Before | After |
|---|---|---|
| Click 'COVID March 2020' featured card | (no UI) | ~250 ms cache-hit |
| Type 'COVID March 2020' (cold)         | 5300 ms LLM | ~250 ms cache-hit |
| Type 'covid 2020' (variant)            | 5300 ms LLM | ~250 ms cache-hit (queryHash collapses) |

Display fields (`blurb`, `range`) are friendly card text; not used by any cache key or downstream code.